### PR TITLE
do not start fuse if missing environment information

### DIFF
--- a/src/fuse/fuse.c
+++ b/src/fuse/fuse.c
@@ -1180,6 +1180,12 @@ int main(int argc, char *argv[])
   marfs_oper.fsync = fuse_fsync;
   marfs_oper.release = fuse_release;
 
+  if ( getenv("MARFS_CONFIG_PATH") == NULL )
+  {
+    fprintf(stderr, "MARFS_CONFIG_PATH is not specified, will not start fuse.\n");
+    return EXIT_FAILURE;
+  }
+
 //  if ((getuid() != 0) || (geteuid() != 0))
 //  {
 //    LOG( LOG_ERR, "Cannot be run by non-root user\n" );


### PR DESCRIPTION
This is for convenience / increasing usability and making the marfs-fuse program easier to use. Not specifying the necessary environment variable is likely a common beginner mistake when setting up marfs-fuse so this will make the program friendlier in that case.