### PR TITLE
always check directory perms when starting fuse

### DIFF
--- a/src/api/marfs.h
+++ b/src/api/marfs.h
@@ -100,8 +100,6 @@ typedef enum
  *         maintaining access to the MDAL/DAL root dirs via the returned marfs_ctxt.
  * @param const char* configpath : Path of the config file to initialize based on
  * @param marfs_interface type : Interface type to use for MarFS ops ( interactive / batch )
- * @param char verify : If zero, skip config verification
- *                      If non-zero, verify the config and abort if any problems are found
  * @param pthread_mutex_t* erasurelock : Reference to a pthread_mutex lock, to be used for synchronizing access
  *                                       to isa-l erasure generation functions in multi-threaded programs.
  *                                       If NULL, marfs will create such a lock internally.  In such a case,
@@ -112,7 +110,7 @@ typedef enum
  *                                       ALL marfs_init() calls.
  * @return marfs_ctxt : Newly initialized marfs_ctxt, or NULL if a failure occurred
  */
-marfs_ctxt marfs_init(const char* configpath, marfs_interface type, char verify, pthread_mutex_t* erasurelock);
+marfs_ctxt marfs_init(const char* configpath, marfs_interface type, pthread_mutex_t* erasurelock);
 
 /**
  * Sets a string 'tag' value for the given context struct, causing all output files to 

--- a/src/api/testing/test_marfsapi.c
+++ b/src/api/testing/test_marfsapi.c
@@ -137,14 +137,15 @@ int main( int argc, char** argv ) {
       return -1;
    }
    marfs_config* verconf = config_init( "testing/config.xml", &erasurelock );
-   if ( config_verify( verconf, ".", 1, 1, 1, 1 ) ) {
+   int flags = CFG_FIX | CFG_OWNERCHECK | CFG_MDALCHECK | CFG_DALCHECK | CFG_RECURSE;
+   if ( config_verify( verconf, ".", flags ) ) {
       printf( "failed to verify batch ctxt config\n" );
       return -1;
    }
    config_term( verconf );
 
    // initialize our BATCH marfs ctxt
-   marfs_ctxt batchctxt = marfs_init( "testing/config.xml", MARFS_BATCH, 0, NULL );
+   marfs_ctxt batchctxt = marfs_init( "testing/config.xml", MARFS_BATCH, NULL );
    if ( batchctxt == NULL ) {
       printf( "failed to initialize batch ctxt\n" );
       return -1;
@@ -157,7 +158,7 @@ int main( int argc, char** argv ) {
    }
 
    // initialize our INTERACTIVE marfs ctxt
-   marfs_ctxt interctxt = marfs_init( "testing/config.xml", MARFS_INTERACTIVE, 1, &erasurelock );
+   marfs_ctxt interctxt = marfs_init( "testing/config.xml", MARFS_INTERACTIVE, &erasurelock );
    if ( interctxt == NULL ) {
       printf( "failed to initialize inter ctxt\n" );
       return -1;

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -3232,13 +3232,15 @@ HASH_TABLE config_genreftable( HASH_NODE** refnodes, size_t* refnodecount, size_
  *  reference dirs in the given config, and verifies the LibNE CTXT
  * @param marfs_config* config : Reference to the config to be validated
  * @param const char* tgtNS : Path of the NS to be verified
- * @param char MDALcheck : If non-zero, the MDAL security and reference dirs of each encountered NS will be verified
- * @param char NEcheck : If non-zero, the LibNE ctxt of each encountered NS will be verified
- * @param char recurse : If non-zero, children of the target NS will also be verified
- * @param char fix : If non-zero, attempt to correct any problems encountered
+ * @param int flags : flags to control behavior of the verification
  * @return int : A count of uncorrected errors encountered, or -1 if a failure occurred
  */
-int config_verify( marfs_config* config, const char* tgtNS, char MDALcheck, char NEcheck, char recurse, char fix ) {
+int config_verify( marfs_config* config, const char* tgtNS, int flags ) {
+
+   int MDALcheck = flags & CFG_MDALCHECK;
+   int NEcheck   = flags & CFG_DALCHECK;
+   int recurse   = flags & CFG_RECURSE;
+   int fix       = flags & CFG_FIX;
 
    // check for NULL refs
    if ( config == NULL ) {
@@ -3350,7 +3352,7 @@ int config_verify( marfs_config* config, const char* tgtNS, char MDALcheck, char
             }
          }
          if ( checkmdalsec ) {
-            int verres = curmdal->checksec( curmdal->ctxt, fix );
+            int verres = curmdal->checksec( curmdal->ctxt, flags );
             if ( verres < 0 ) {
                LOG( LOG_ERR, "Failed to verify the MDAL security of repo: \"%s\" (%s)\n",
                              pos.ns->prepo->name, strerror(errno) );
@@ -3366,7 +3368,7 @@ int config_verify( marfs_config* config, const char* tgtNS, char MDALcheck, char
             }
          }
          if ( checklibne ) {
-            int verres = ne_verify( pos.ns->prepo->datascheme.nectxt, fix );
+            int verres = ne_verify( pos.ns->prepo->datascheme.nectxt, flags );
             if ( verres < 0 ) {
                LOG( LOG_ERR, "Failed to verify ne_ctxt of repo: \"%s\" (%s)\n",
                              pos.ns->prepo->name, strerror(errno) );

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -145,6 +145,15 @@ typedef struct marfs_position_struct {
    MDAL_CTXT ctxt;
 } marfs_position;
 
+// flags for config_verify
+enum {
+   CFG_FIX          = 0x1,  // fix problems found with the config
+   CFG_OWNERCHECK   = 0x2,  // check owner of MDAL "security directory"
+   CFG_MDALCHECK    = 0x4,  // check MDAL
+   CFG_DALCHECK     = 0x8,  // check NE (DAL)
+   CFG_RECURSE      = 0x10, // recursively check children of the namespace
+};
+
 /**
  * Initialize memory structures based on the given config file
  * @param const char* cpath : Path of the config file to be parsed
@@ -220,13 +229,10 @@ HASH_TABLE config_genreftable( HASH_NODE** refnodes, size_t* refnodecount, size_
  *  reference dirs in the given config, and verifies the LibNE CTXT
  * @param marfs_config* config : Reference to the config to be validated
  * @param const char* tgtNS : Path of the NS to be verified
- * @param char MDALcheck : If non-zero, the MDAL security and reference dirs of each encountered NS will be verified
- * @param char NEcheck : If non-zero, the LibNE ctxt of each encountered NS will be verified
- * @param char recurse : If non-zero, children of the target NS will also be verified
- * @param char fix : If non-zero, attempt to correct any problems encountered
+ * @param int flags : flags to control behavior of the verification
  * @return int : A count of uncorrected errors encountered, or -1 if a failure occurred
  */
-int config_verify( marfs_config* config, const char* tgtNS, char MDALcheck, char NEcheck, char recurse, char fix );
+int config_verify( marfs_config* config, const char* tgtNS, int flags );
 
 /**
  * Traverse the given path, idetifying a final NS target and resulting subpath

--- a/src/config/testing/test_config.c
+++ b/src/config/testing/test_config.c
@@ -556,7 +556,8 @@ int main(int argc, char **argv)
 
 
    // prepare for full path traversal by actually creating config namespaces
-   if ( config_verify(config,"/campaign/",1,1,1,1) ) {
+   int flags = CFG_FIX | CFG_OWNERCHECK | CFG_MDALCHECK | CFG_DALCHECK | CFG_RECURSE;
+   if ( config_verify(config,"/campaign/",flags ) ) {
       printf( "Config validation failure\n" );
       return -1;
    }

--- a/src/config/verifyconf.c
+++ b/src/config/verifyconf.c
@@ -81,10 +81,7 @@ int main(int argc, const char** argv) {
    char* config_path = getenv( "MARFS_CONFIG_PATH" ); // check for config env var
    char* ns_path = ".";
    char* user_name = NULL;
-   char mdalcheck = 0;
-   char necheck = 0;
-   char recurse = 0;
-   char fix = 0;
+   int flags = CFG_OWNERCHECK;
 
    // parse all position-independent arguments
    char pr_usage = 0;
@@ -101,22 +98,22 @@ int main(int argc, const char** argv) {
          user_name = optarg;
          break;
       case 'm':
-         mdalcheck = 1;
+         flags |= CFG_MDALCHECK;
          break;
       case 'd':
-         necheck = 1;
+         flags |= CFG_DALCHECK;
          break;
       case 'r':
-         recurse = 1;
+         flags |= CFG_RECURSE;
          break;
       case 'f':
-         fix = 1;
+         flags |= CFG_FIX;
          break;
       case 'a':
-         mdalcheck = 1;
-         necheck = 1;
-         recurse = 1;
-         fix = 1;
+         flags |= CFG_MDALCHECK;
+         flags |= CFG_DALCHECK;
+         flags |= CFG_RECURSE;
+         flags |= CFG_FIX;
          break;
       case '?':
          printf( OUTPREFX "ERROR: Unrecognized cmdline argument: \'%c\'\n", optopt );
@@ -210,7 +207,8 @@ int main(int argc, const char** argv) {
    }
 
    // verify the config
-   int verres = config_verify(config, ns_path, mdalcheck, necheck, recurse, fix);
+   int verres = config_verify(config, ns_path, flags);
+
    if ( config_term(config) ) {
       printf(OUTPREFX "WARNING: Failed to properly terminate MarFS config ( %s )\n", strerror(errno));
    }

--- a/src/datastream/testing/test_datastream.c
+++ b/src/datastream/testing/test_datastream.c
@@ -151,7 +151,8 @@ int main(int argc, char **argv)
    }
 
    // create all namespaces associated with the config
-   if ( config_verify( config, "./.", 1, 1, 1, 1 ) ) {
+   int flags = CFG_FIX | CFG_OWNERCHECK | CFG_MDALCHECK | CFG_DALCHECK | CFG_RECURSE;
+   if ( config_verify( config, "./.", flags ) ) {
       printf( "Failed to validate the marfs config\n" );
       return -1;
    }

--- a/src/datastream/testing/test_datastream_rebuilds.c
+++ b/src/datastream/testing/test_datastream_rebuilds.c
@@ -121,6 +121,7 @@ int main(int argc, char **argv)
 
    // Initialize the libxml lib and check for API mismatches
    LIBXML_TEST_VERSION
+   int flags = CFG_FIX | CFG_OWNERCHECK | CFG_MDALCHECK | CFG_DALCHECK | CFG_RECURSE;
 
    // create the dirs necessary for DAL/MDAL initialization (ignore EEXIST)
    errno = 0;
@@ -152,7 +153,7 @@ int main(int argc, char **argv)
    }
 
    // create all namespaces associated with the config
-   if ( config_verify( config, "./.", 1, 1, 1, 1 ) ) {
+   if ( config_verify( config, "./.", flags ) ) {
       printf( "Failed to validate the marfs config\n" );
       return -1;
    }
@@ -301,7 +302,7 @@ int main(int argc, char **argv)
 
 
    // reverify the config, so we actually have a block location to rebuild into
-   if ( config_verify( config, "./.", 1, 1, 1, 1 ) ) {
+   if ( config_verify( config, "./.", flags ) ) {
       printf( "Failed to re-validate the marfs config\n" );
       return -1;
    }

--- a/src/datastream/testing/test_datastream_repack.c
+++ b/src/datastream/testing/test_datastream_repack.c
@@ -151,7 +151,8 @@ int main(int argc, char **argv)
    }
 
    // create all namespaces associated with the config
-   if ( config_verify( config, "./.", 1, 1, 1, 1 ) ) {
+   int flags = CFG_FIX | CFG_OWNERCHECK | CFG_MDALCHECK | CFG_DALCHECK | CFG_RECURSE;
+   if ( config_verify( config, "./.", flags ) ) {
       printf( "Failed to validate the marfs config\n" );
       return -1;
    }

--- a/src/fuse/fuse.c
+++ b/src/fuse/fuse.c
@@ -1161,9 +1161,7 @@ void marfs_fuse_init(void)
     exit(-1);
   }
   // initialize the MarFS config
-  // NOTE -- FUSE doesn't attempt to verify the config, as it will almost always be run as root.
-  //         We want to allow the 'secure root dir' to be owned by a non-root user, if desired.
-  fctxt->ctxt = marfs_init(getenv("MARFS_CONFIG_PATH"), MARFS_INTERACTIVE, 0, &(fctxt->erasurelock));
+  fctxt->ctxt = marfs_init( getenv("MARFS_CONFIG_PATH"), MARFS_INTERACTIVE, &(fctxt->erasurelock) );
   if ( fctxt->ctxt == NULL ) {
     fprintf( stderr, "Failed to initialize MarFS context!\n" );
     pthread_mutex_destroy( &(fctxt->erasurelock) );

--- a/src/mdal/mdal.h
+++ b/src/mdal/mdal.h
@@ -137,10 +137,12 @@ typedef struct MDAL_struct {
     * @param const MDAL_CTXT ctxt : MDAL_CTXT for which to verify security
     *                               NOTE -- this ctxt CANNOT be associated with a NS target
     *                                       ( it must be freshly initialized )
-    * @param char fix : If non-zero, attempt to correct any problems encountered
+    * @param int flags : currently uses CFG_FIX (correct any problems if true)
+    *                    and CFG_OWNERCHECK (check that UID of parent security dir
+    *                                        matches current user if true)
     * @return int : A count of uncorrected security issues, or -1 if a failure occurred
     */
-   int (*checksec) ( const MDAL_CTXT ctxt, char fix );
+   int (*checksec) ( const MDAL_CTXT ctxt, int flags );
 
 
    // Namespace Functions

--- a/src/rsrc_mgr/new_rsrc_mgr.c
+++ b/src/rsrc_mgr/new_rsrc_mgr.c
@@ -1490,7 +1490,8 @@ int main(int argc, char** argv) {
   }
 
   if (config_v) {
-    if (config_verify(cfg, ".", 1, 1, 1, 1)) {
+    int flags = CFG_FIX | CFG_OWNERCHECK | CFG_MDALCHECK | CFG_DALCHECK | CFG_RECURSE;
+    if (config_verify(cfg, ".", flags)) {
       fprintf(stderr, OUTPREFX "Rank %d: Failed to verify config: %s\n", rank, strerror(errno));
       config_term(cfg);
       return -1;

--- a/src/rsrc_mgr/rsrc_mgr.c
+++ b/src/rsrc_mgr/rsrc_mgr.c
@@ -1478,7 +1478,8 @@ int main(int argc, char** argv) {
   }
 
   if (config_v) {
-    if (config_verify(cfg, ".", 1, 1, 1, 1)) {
+    int flags = CFG_FIX | CFG_OWNERCHECK | CFG_MDALCHECK | CFG_DALCHECK | CFG_RECURSE;
+    if (config_verify(cfg, ".", flags)) {
       fprintf(stderr, OUTPREFX "Rank %d: Failed to verify config: %s\n", rank, strerror(errno));
       config_term(cfg);
       return -1;

--- a/src/rsrc_mgr/testing/test_resourcelog.c
+++ b/src/rsrc_mgr/testing/test_resourcelog.c
@@ -140,7 +140,8 @@ int main(int argc, char **argv)
       printf( "failed to initalize marfs config\n" );
       return -1;
    }
-   if ( config_verify(config,"/campaign/",1,1,1,1) ) {
+   int flags = CFG_FIX | CFG_OWNERCHECK | CFG_MDALCHECK | CFG_DALCHECK | CFG_RECURSE;
+   if ( config_verify(config,"/campaign/",flags) ) {
       printf( "Config validation failure\n" );
       return -1;
    }

--- a/src/rsrc_mgr/testing/test_resourceprocessing.c
+++ b/src/rsrc_mgr/testing/test_resourceprocessing.c
@@ -154,7 +154,8 @@ int main(int argc, char **argv)
    }
 
    // create all namespaces associated with the config
-   if ( config_verify( config, "./.", 1, 1, 1, 1 ) ) {
+   int flags = CFG_FIX | CFG_OWNERCHECK | CFG_MDALCHECK | CFG_DALCHECK | CFG_RECURSE;
+   if ( config_verify( config, "./.", flags ) ) {
       printf( "Failed to validate the marfs config\n" );
       return -1;
    }

--- a/src/rsrc_mgr/testing/test_resourcethreads.c
+++ b/src/rsrc_mgr/testing/test_resourcethreads.c
@@ -158,7 +158,8 @@ int main(int argc, char **argv)
    }
 
    // create all namespaces associated with the config
-   if ( config_verify( config, "./.", 1, 1, 1, 1 ) ) {
+   int flags = CFG_FIX | CFG_OWNERCHECK | CFG_MDALCHECK | CFG_DALCHECK | CFG_RECURSE;
+   if ( config_verify( config, "./.", flags ) ) {
       printf( "Failed to validate the marfs config\n" );
       return -1;
    }

--- a/src/rsrc_mgr/testing/test_rsrc_mgr.c
+++ b/src/rsrc_mgr/testing/test_rsrc_mgr.c
@@ -98,7 +98,8 @@ int main(int argc, char** argv) {
   }
 
   // create all namespaces associated with the config
-  if (config_verify(config, "/campaign", 1, 1, 1, 1)) {
+  int flags = CFG_FIX | CFG_OWNERCHECK | CFG_MDALCHECK | CFG_DALCHECK | CFG_RECURSE;
+  if (config_verify(config, "/campaign", flags)) {
     printf("Failed to validate the marfs config\n");
     return -1;
   }

--- a/src/rsrc_mgr/testing/test_rsrc_mgr_nopack.c
+++ b/src/rsrc_mgr/testing/test_rsrc_mgr_nopack.c
@@ -99,7 +99,8 @@ int main(int argc, char** argv) {
   }
 
   // create all namespaces associated with the config
-  if (config_verify(config, ".././campaign", 1, 1, 1, 1)) {
+  int flags = CFG_FIX | CFG_OWNERCHECK | CFG_MDALCHECK | CFG_DALCHECK | CFG_RECURSE;
+  if (config_verify(config, ".././campaign", flags)) {
     printf("Failed to validate the marfs config\n");
     return -1;
   }


### PR DESCRIPTION
This commit changes the posixmdal_checksec() function to take a parameter that determines whether to check directory ownership for the parent dir(s) of the MarFS metadata directory. This flag is needed because when running MarFS, we want to check for permissions of the parent dir(s) but not ownership, since it is permissible to run MarFS under a different user than the one who owns the directory (for example, run FUSE as root while directory is owned by a regular user).

marfs_init() is now modified to always run config_verify() prior to launching MarFS, and it calls config_verify() with the check ownership flag false.

marfs_verifyconf() always runs config_verify() with the new check ownership flag true.

In addition, the signatures of the config_verify() and posixmdal_checksec() are modified to take a single `int flags` argument containing the relevant flags for these functions, instead of multiple char args for each flag individually. This should simplify adding further parameters in the future.

The flags specified in this commit should be kept in sync with the flags in the LibNE source that are used for the DAL config verification functions.