### PR TITLE
include <stdlib.h> where needed

### DIFF
--- a/src/dal/testing/test_dal.c
+++ b/src/dal/testing/test_dal.c
@@ -61,6 +61,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #include "dal/dal.h"
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {

--- a/src/dal/testing/test_dal_abort.c
+++ b/src/dal/testing/test_dal_abort.c
@@ -62,6 +62,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #include <unistd.h>
 #include <stdio.h>
 #include <fcntl.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {

--- a/src/dal/testing/test_dal_fuzzing.c
+++ b/src/dal/testing/test_dal_fuzzing.c
@@ -61,6 +61,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #include "dal/dal.h"
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {

--- a/src/dal/testing/test_dal_fuzzing_put.c
+++ b/src/dal/testing/test_dal_fuzzing_put.c
@@ -61,6 +61,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #include "dal/dal.h"
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {

--- a/src/dal/testing/test_dal_migrate.c
+++ b/src/dal/testing/test_dal_migrate.c
@@ -61,6 +61,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #include "dal/dal.h"
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {

--- a/src/dal/testing/test_dal_noop.c
+++ b/src/dal/testing/test_dal_noop.c
@@ -61,6 +61,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #include "dal/dal.h"
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {

--- a/src/dal/testing/test_dal_oflags.c
+++ b/src/dal/testing/test_dal_oflags.c
@@ -61,6 +61,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #include "dal/dal.h"
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {

--- a/src/dal/testing/test_dal_timer.c
+++ b/src/dal/testing/test_dal_timer.c
@@ -62,6 +62,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #include <unistd.h>
 #include <stdio.h>
 #include <ftw.h>
+#include <stdlib.h>
 
 // WARNING: error-prone and ugly method of deleting files, written for simplicity only
 //          don't replicate this junk into ANY production code paths!

--- a/src/dal/testing/test_dal_timer_abort.c
+++ b/src/dal/testing/test_dal_timer_abort.c
@@ -62,6 +62,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #include <unistd.h>
 #include <stdio.h>
 #include <fcntl.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {

--- a/src/dal/testing/test_dal_timer_migrate.c
+++ b/src/dal/testing/test_dal_timer_migrate.c
@@ -61,6 +61,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #include "dal/dal.h"
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {

--- a/src/io/testing/bufferfuncs.c
+++ b/src/io/testing/bufferfuncs.c
@@ -63,6 +63,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #include "dal/dal.h"
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 
 // sentinel values to ensure good data transfer

--- a/src/io/testing/test_ioqueue.c
+++ b/src/io/testing/test_ioqueue.c
@@ -63,6 +63,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #include "dal/dal.h"
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 
 // sentinel values to ensure good data transfer


### PR DESCRIPTION
This fixes the build on a system where running `make check` has build errors due to <stdlib.h> needing to be included in order to use malloc(), free(), etc.