### PR TITLE
Minor Headerfile Changes

### DIFF
--- a/src/config/Makefile.am
+++ b/src/config/Makefile.am
@@ -21,6 +21,8 @@ libConfig_la_LIBADD  = ../hash/libHash.la ../mdal/libMDAL.la ../ne/libne.la
 libConfig_la_CFLAGS  = $(XML_CFLAGS)
 CONFIG_LIB = libConfig.la
 
+include_HEADERS = config.h
+
 bin_PROGRAMS = marfs-verifyconf
 marfs_verifyconf_SOURCES = verifyconf.c
 marfs_verifyconf_LDADD   = $(CONFIG_LIB)

--- a/src/ne/ne.h
+++ b/src/ne/ne.h
@@ -58,9 +58,6 @@ extern "C"
 
 #define UNSAFE(HANDLE, NERR) ((NERR) && (NERR > ((HANDLE)->erasure_state->E - MIN_PROTECTION)))
 
-typedef uint32_t u32;
-typedef uint64_t u64;
-
 // NOTE -- the values of zero and 1 are reserved for internal use (by handles created via ne_stat())
 typedef enum
 {
@@ -93,7 +90,7 @@ typedef struct ne_state_struct
  char *data_status; // user allocated region, must be at least ( sizeof(char) * max_block ) bytes; ignored if NULL
 
  // per-part info
- u64 *csum; // user allocated region, must be at least ( sizeof(u64) * max_block ) bytes; ignored if NULL
+ uint64_t *csum; // user allocated region, must be at least ( sizeof(uint64_t) * max_block ) bytes; ignored if NULL
 } ne_state;
 
 // location struct


### PR DESCRIPTION
Minor changes to install config.h include file and avoid pointless / possibly conflicting redefinition of uint*_t types in ne.h